### PR TITLE
Dependency against libwww-perl if running against older distribution.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,6 @@ Package: rpimonitor
 Version: {DEVELOPMENT}
 Architecture: all
 Section: misc
-Depends: perl, librrds-perl, libhttp-daemon-perl, libjson-perl, libipc-sharelite-perl
+Depends: perl, librrds-perl, libhttp-daemon-perl (>= 6.0.0) | libwww-perl (<< 6.0.0), libjson-perl, libipc-sharelite-perl
 Maintainer: Xavier Berger <berger.xavier@gmail.com>
 Description: RPi-Monitor is a self monitoring application designed to run on Raspberry Pi.


### PR DESCRIPTION
This is just a detail, but `HTTP::Daemon` is in package `libwww-perl`, not `libhttp-daemon-perl` in older versions of `libwww-perl` and `HTTP::Daemon` (there was a change between `libwww-perl` 5.x and 6.x).

This patch allows for the installation of this package on older (Squeeze) images. (It seems to work with `libwww-perl` 5.836.)
